### PR TITLE
enabled chartFn functionality

### DIFF
--- a/OpenCharts/charts/Chart.js
+++ b/OpenCharts/charts/Chart.js
@@ -109,7 +109,7 @@ Ext.define('OpenCharts.charts.Chart',{
         
             //apply additional properties specific to each chartType
             //the various chart classes will override this method
-            this.applyChartProperties(chart, options);
+            this.applyChartProperties(chart, options, this.getChartFn());
             
             //now we need to bind the various chart events so we can fire these
             //events for Sencha Touch


### PR DESCRIPTION
I might be missing 'something', but it looks like the chartFn function is not called because of the missing 3th parameter in the call to applyChartProperties. This change works for me, but breaks some examples, such as the LinePlusBarChart example. 

The chartFn function in that example is never called without applying this change. After that, the function is actually called but the 'data' variable is undefined and I can't see where that is supposed to be coming from.

```
  var dx = data[0].values[d] && data[0].values[d][0] || 0;
```
